### PR TITLE
M5: orthogonal persistence — EF-Core-style DbContext over stable memory

### DIFF
--- a/aot/Wasp.OrthogonalPersistence.Tests/Wasp.OrthogonalPersistence.Tests.csproj
+++ b/aot/Wasp.OrthogonalPersistence.Tests/Wasp.OrthogonalPersistence.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Wasp.OrthogonalPersistence/Wasp.OrthogonalPersistence.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+  </ItemGroup>
+
+</Project>

--- a/aot/Wasp.OrthogonalPersistence.Tests/WaspDbSetTests.cs
+++ b/aot/Wasp.OrthogonalPersistence.Tests/WaspDbSetTests.cs
@@ -1,0 +1,79 @@
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Wasp.OrthogonalPersistence;
+using Xunit;
+
+// Pure in-memory exercise of the WaspDbSet<T> + WaspDbContext API.
+// Storage (Save/Load) requires Ic0 stable_* syscalls so isn't testable
+// outside a canister; verified live in samples/TodoEf instead.
+public partial class WaspDbSetTests
+{
+    public sealed class Product
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public decimal Price { get; set; }
+    }
+
+    [JsonSerializable(typeof(Product))]
+    [JsonSerializable(typeof(Product[]))]
+    [JsonSerializable(typeof(System.Collections.Generic.Dictionary<string, object>))]
+    [JsonSerializable(typeof(object))]
+    public partial class TestCtx : JsonSerializerContext { }
+
+    private sealed class ShopContext : WaspDbContext
+    {
+        public WaspDbSet<Product> Products { get; }
+        public ShopContext(JsonSerializerOptions json) : base(json)
+        {
+            Products = new WaspDbSet<Product>(this, "products");
+        }
+    }
+
+    private static JsonSerializerOptions Options() => new()
+    {
+        TypeInfoResolver = TestCtx.Default,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public void Add_increases_count()
+    {
+        var ctx = new ShopContext(Options());
+        ctx.Products.Add(new Product { Id = 1, Name = "Apple", Price = 0.5m });
+        ctx.Products.Add(new Product { Id = 2, Name = "Bread", Price = 2.0m });
+        Assert.Equal(2, ctx.Products.Count);
+    }
+
+    [Fact]
+    public void Remove_drops_the_item()
+    {
+        var ctx = new ShopContext(Options());
+        var p = new Product { Id = 1, Name = "Apple" };
+        ctx.Products.Add(p);
+        Assert.True(ctx.Products.Remove(p));
+        Assert.Equal(0, ctx.Products.Count);
+    }
+
+    [Fact]
+    public void Linq_query_against_dbset_works()
+    {
+        var ctx = new ShopContext(Options());
+        ctx.Products.Add(new Product { Id = 1, Name = "Apple", Price = 0.5m });
+        ctx.Products.Add(new Product { Id = 2, Name = "Anvil", Price = 99.0m });
+        ctx.Products.Add(new Product { Id = 3, Name = "Bread", Price = 2.0m });
+        var cheap = ctx.Products.Where(p => p.Price < 10m).Select(p => p.Name).ToArray();
+        Assert.Equal(new[] { "Apple", "Bread" }, cheap);
+    }
+
+    [Fact]
+    public void Find_returns_matching_or_null()
+    {
+        var ctx = new ShopContext(Options());
+        ctx.Products.Add(new Product { Id = 1, Name = "Apple" });
+        ctx.Products.Add(new Product { Id = 2, Name = "Bread" });
+        Assert.Equal("Bread", ctx.Products.Find(p => p.Id == 2)?.Name);
+        Assert.Null(ctx.Products.Find(p => p.Id == 999));
+    }
+}

--- a/aot/Wasp.OrthogonalPersistence/Wasp.OrthogonalPersistence.csproj
+++ b/aot/Wasp.OrthogonalPersistence/Wasp.OrthogonalPersistence.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Wasp.OrthogonalPersistence</RootNamespace>
+    <AssemblyName>Wasp.OrthogonalPersistence</AssemblyName>
+    <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>true</IsPackable>
+    <PackageId>Wasp.OrthogonalPersistence</PackageId>
+    <Version>0.1.0-alpha</Version>
+    <Description>
+      Orthogonal persistence for Wasp canisters: WaspDbContext +
+      WaspDbSet&lt;T&gt; mirror EF Core's DbContext/DbSet API
+      (Add / Remove / Find / SaveChanges, plus IEnumerable for LINQ)
+      but persist to stable memory instead of SQL. Fits inside the
+      IC's 11.5 MB wasm code-section limit; no migrations, no
+      connection strings.
+    </Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Wasp.IcCdk\Wasp.IcCdk.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/aot/Wasp.OrthogonalPersistence/src/Storage.cs
+++ b/aot/Wasp.OrthogonalPersistence/src/Storage.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Text;
+using Wasp.IcCdk;
+
+namespace Wasp.OrthogonalPersistence;
+
+/// <summary>
+/// Single-chunk stable-memory snapshot. Layout at offset
+/// <c>StableOffset</c>:
+///   uint32  magic ("WAOP" = 0x57414f50)
+///   uint32  version (1)
+///   uint32  utf8 byte length
+///   bytes   JSON payload
+///
+/// The chunk grows on write — pages are added in 64 KB increments as
+/// needed.
+/// </summary>
+internal static unsafe class Storage
+{
+    private const uint Magic = 0x57414f50;  // "WAOP"
+    private const uint Version = 1;
+    private const int HeaderLength = 12;
+
+    internal static void Write(ulong offset, string json)
+    {
+        var data = Encoding.UTF8.GetBytes(json);
+        ulong needed = offset + (ulong)HeaderLength + (ulong)data.Length;
+        ulong haveBytes = Ic0.stable64_size() * 65536UL;
+        if (needed > haveBytes)
+        {
+            ulong morePages = ((needed - haveBytes) + 65535UL) / 65536UL;
+            Ic0.stable64_grow(morePages);
+        }
+        Span<byte> header = stackalloc byte[HeaderLength];
+        BitConverter.TryWriteBytes(header, Magic);
+        BitConverter.TryWriteBytes(header.Slice(4), Version);
+        BitConverter.TryWriteBytes(header.Slice(8), data.Length);
+        fixed (byte* p = header) Ic0.stable64_write(offset, (ulong)(nint)p, (ulong)HeaderLength);
+        fixed (byte* p = data) Ic0.stable64_write(offset + (ulong)HeaderLength, (ulong)(nint)p, (ulong)data.Length);
+    }
+
+    internal static string? Read(ulong offset)
+    {
+        if (Ic0.stable64_size() == 0) return null;
+        Span<byte> header = stackalloc byte[HeaderLength];
+        fixed (byte* p = header) Ic0.stable64_read((ulong)(nint)p, offset, (ulong)HeaderLength);
+        if (BitConverter.ToUInt32(header) != Magic) return null;
+        if (BitConverter.ToUInt32(header.Slice(4)) != Version) return null;
+        var length = BitConverter.ToInt32(header.Slice(8));
+        if (length <= 0 || length > 64 * 1024 * 1024) return null;  // 64 MB cap
+        var data = new byte[length];
+        fixed (byte* p = data) Ic0.stable64_read((ulong)(nint)p, offset + (ulong)HeaderLength, (ulong)length);
+        return Encoding.UTF8.GetString(data);
+    }
+}

--- a/aot/Wasp.OrthogonalPersistence/src/WaspDbContext.cs
+++ b/aot/Wasp.OrthogonalPersistence/src/WaspDbContext.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Wasp.OrthogonalPersistence;
+
+/// <summary>
+/// EF-Core-style "DbContext" backed by canister stable memory. The
+/// developer subclasses this, declares <see cref="WaspDbSet{T}"/>
+/// properties, and gets persistence "for free" — every
+/// <see cref="SaveChanges"/> snapshots every set to a single chunk of
+/// stable memory.
+///
+/// Mental model: orthogonal persistence. State that lives in the
+/// context's sets survives canister upgrades, redeploys, hours of
+/// idle time, replica restarts. No SQL, no migrations, no DBAs.
+///
+/// Trade-off: every SaveChanges rewrites the whole snapshot. Fine for
+/// dapps up to roughly a few MB of total state — past that, switch to
+/// chunked / shard / dedicated stable-memory layouts.
+/// </summary>
+public abstract class WaspDbContext
+{
+    private readonly List<IWaspDbSetInternal> _sets = new();
+    private readonly JsonSerializerOptions _json;
+    private readonly ulong _stableOffset;
+
+    /// <summary>
+    /// Create the context. <paramref name="jsonOptions"/> MUST carry a
+    /// source-gen <c>JsonSerializerContext</c> resolver covering every
+    /// entity type in this context, otherwise serialisation will fail
+    /// under AOT trimming.
+    /// </summary>
+    protected WaspDbContext(JsonSerializerOptions jsonOptions, ulong stableOffset = 65536)
+    {
+        _json = jsonOptions ?? throw new ArgumentNullException(nameof(jsonOptions));
+        _stableOffset = stableOffset;
+    }
+
+    /// <summary>
+    /// Called by <see cref="WaspDbSet{T}"/>'s constructor. Don't call
+    /// directly — declare sets as `public WaspDbSet&lt;T&gt; Xs { get; }`
+    /// and instantiate them in the constructor.
+    /// </summary>
+    internal void Register(IWaspDbSetInternal set) => _sets.Add(set);
+
+    public int SaveChanges()
+    {
+        var snapshot = new Dictionary<string, object>(_sets.Count);
+        foreach (var set in _sets) snapshot[set.Name] = set.SnapshotForSerialize();
+        var json = JsonSerializer.Serialize(snapshot, typeof(Dictionary<string, object>), _json);
+        Storage.Write(_stableOffset, json);
+        return _sets.Count;
+    }
+
+    public void Load()
+    {
+        var json = Storage.Read(_stableOffset);
+        if (json is null) return;
+        // Parse to a Dictionary<string, JsonElement>. The element-array
+        // for each set is then deserialised by the set itself, which
+        // knows its T.
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        if (root.ValueKind != JsonValueKind.Object) return;
+        foreach (var set in _sets)
+        {
+            if (!root.TryGetProperty(set.Name, out var element)) continue;
+            set.LoadFromJson(element, _json);
+        }
+    }
+}
+
+internal interface IWaspDbSetInternal
+{
+    string Name { get; }
+    object SnapshotForSerialize();
+    void LoadFromJson(JsonElement element, JsonSerializerOptions options);
+}

--- a/aot/Wasp.OrthogonalPersistence/src/WaspDbSet.cs
+++ b/aot/Wasp.OrthogonalPersistence/src/WaspDbSet.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace Wasp.OrthogonalPersistence;
+
+/// <summary>
+/// EF-Core-style collection of entities. Mirrors the
+/// <c>DbSet&lt;T&gt;</c> surface developers already know:
+/// <c>Add</c>, <c>Remove</c>, <c>Find</c>, plus
+/// <c>IEnumerable&lt;T&gt;</c> for LINQ.
+///
+/// Entity equality is by reference; deletion uses the same instance
+/// you added. To support id-based lookup, expose an integer
+/// <c>Id</c> property on your entity and use <c>FirstOrDefault</c>.
+/// </summary>
+public sealed class WaspDbSet<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T> : IEnumerable<T>, IWaspDbSetInternal
+    where T : class
+{
+    private readonly List<T> _items = new();
+    private readonly string _name;
+
+    public WaspDbSet(WaspDbContext parent, string name)
+    {
+        _name = name;
+        parent.Register(this);
+    }
+
+    public int Count => _items.Count;
+
+    public void Add(T item) => _items.Add(item ?? throw new ArgumentNullException(nameof(item)));
+
+    public bool Remove(T item) => _items.Remove(item ?? throw new ArgumentNullException(nameof(item)));
+
+    public T? Find(Predicate<T> match) => _items.Find(match);
+
+    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    // ─── Internal: snapshot + load ────────────────────────────────────
+    string IWaspDbSetInternal.Name => _name;
+
+    object IWaspDbSetInternal.SnapshotForSerialize() => _items.ToArray();
+
+    void IWaspDbSetInternal.LoadFromJson(JsonElement element, JsonSerializerOptions options)
+    {
+        if (element.ValueKind != JsonValueKind.Array) return;
+        _items.Clear();
+        foreach (var child in element.EnumerateArray())
+        {
+            var raw = child.GetRawText();
+            var entity = JsonSerializer.Deserialize<T>(raw, options);
+            if (entity is not null) _items.Add(entity);
+        }
+    }
+}

--- a/aot/dfx.json
+++ b/aot/dfx.json
@@ -105,6 +105,12 @@
       "wasm": "samples/BlazorWasp/BlazorWasp.canister.wasm",
       "candid": "samples/BlazorWasp/blazorwasp.did",
       "build": []
+    },
+    "todoef": {
+      "type": "custom",
+      "wasm": "samples/TodoEf/TodoEf.canister.wasm",
+      "candid": "samples/TodoEf/todoef.did",
+      "build": []
     }
   },
   "networks": {

--- a/aot/samples/TodoEf/Program.cs
+++ b/aot/samples/TodoEf/Program.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Wasp.AspNetCore;
+using Wasp.IcCdk;
+
+namespace WaspSample.TodoEf;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(Todo))]
+[JsonSerializable(typeof(Todo[]))]
+[JsonSerializable(typeof(CreateRequest))]
+[JsonSerializable(typeof(System.Collections.Generic.Dictionary<string, object>))]
+[JsonSerializable(typeof(object))]
+internal partial class TodoJsonCtx : JsonSerializerContext { }
+
+public sealed record CreateRequest(string Title);
+
+public static class Program
+{
+    private static TodoContext? _db;
+
+    [ModuleInitializer]
+    internal static void Init()
+    {
+        try
+        {
+            var builder = WebApplication.CreateEmptyBuilder(new WebApplicationOptions
+            {
+                ContentRootPath = "/canister",
+                ApplicationName = "TodoEf",
+            });
+
+            builder.UseInternetComputer();
+            builder.Services.AddRoutingCore();    // minimal-API endpoints need this
+            builder.Services.ConfigureHttpJsonOptions(o =>
+            {
+                o.SerializerOptions.TypeInfoResolverChain.Clear();
+                o.SerializerOptions.TypeInfoResolverChain.Insert(0, TodoJsonCtx.Default);
+            });
+
+            // Single-tenant DbContext, eagerly hydrated from stable
+            // memory. The render-as-query model means each request
+            // gets the same DbContext singleton — single-threaded
+            // canister + no per-request scoping needed.
+            var jsonOpts = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                TypeInfoResolver = TodoJsonCtx.Default,
+            };
+            _db = new TodoContext(jsonOpts);
+            _db.Load();
+            builder.Services.AddSingleton(_db);
+
+            var app = builder.Build();
+
+            app.MapGet("/", () => Results.Text(
+                "TodoEf — EF-Core-style DbContext on the IC.\n" +
+                "  GET    /todos             list all\n" +
+                "  POST   /todos             body { \"title\": \"...\" }\n" +
+                "  POST   /todos/{id}/toggle\n" +
+                "  DELETE /todos/{id}\n",
+                "text/plain"));
+
+            app.MapGet("/todos", (TodoContext db) => db.Todos.OrderBy(t => t.Id).ToArray());
+
+            app.MapPost("/todos", async (HttpContext ctx, TodoContext db) =>
+            {
+                using var ms = new System.IO.MemoryStream();
+                await ctx.Request.Body.CopyToAsync(ms);
+                var req = JsonSerializer.Deserialize(ms.ToArray(), TodoJsonCtx.Default.CreateRequest);
+                return Results.Json(db.Create(req?.Title ?? "(no title)"));
+            });
+
+            app.MapPost("/todos/{id:int}/toggle", (int id, TodoContext db) =>
+            {
+                var todo = db.Todos.FirstOrDefault(t => t.Id == id);
+                if (todo is null) return Results.NotFound();
+                todo.Done = !todo.Done;
+                db.SaveChanges();
+                return Results.Json(todo);
+            });
+
+            app.MapDelete("/todos/{id:int}", (int id, TodoContext db) =>
+            {
+                var todo = db.Todos.FirstOrDefault(t => t.Id == id);
+                if (todo is null) return Results.NotFound();
+                db.Todos.Remove(todo);
+                db.SaveChanges();
+                return Results.NoContent();
+            });
+
+            app.RunOnIC();
+        }
+        catch (Exception ex)
+        {
+            var msg = ex.GetType().FullName + ": " + ex.Message
+                + (ex.StackTrace is { } st ? "\n" + st : "");
+            IcServer.InitFailureMessage = msg;
+            Reply.Print("[init-fail] " + msg);
+        }
+    }
+}

--- a/aot/samples/TodoEf/TodoContext.cs
+++ b/aot/samples/TodoEf/TodoContext.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using Wasp.OrthogonalPersistence;
+
+namespace WaspSample.TodoEf;
+
+public class Todo
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = "";
+    public bool Done { get; set; }
+    public long CreatedAtMs { get; set; }
+}
+
+/// <summary>
+/// EF-Core-style DbContext on the IC. Same shape developers know
+/// from Entity Framework, but the sets persist to stable memory
+/// instead of SQL — no connection string, no migrations.
+/// </summary>
+public sealed class TodoContext : WaspDbContext
+{
+    public WaspDbSet<Todo> Todos { get; }
+
+    private int _nextId = 1;
+
+    public TodoContext(JsonSerializerOptions json) : base(json)
+    {
+        Todos = new WaspDbSet<Todo>(this, "todos");
+    }
+
+    public Todo Create(string title)
+    {
+        var todo = new Todo
+        {
+            Id = NextId(),
+            Title = title,
+            Done = false,
+            CreatedAtMs = (long)(Wasp.IcCdk.Ic0.time() / 1_000_000UL),
+        };
+        Todos.Add(todo);
+        SaveChanges();
+        return todo;
+    }
+
+    private int NextId()
+    {
+        // First-write seed: walk existing rows so id space stays
+        // monotonic across canister upgrades.
+        if (_nextId == 1)
+        {
+            foreach (var t in Todos)
+                if (t.Id >= _nextId) _nextId = t.Id + 1;
+        }
+        return _nextId++;
+    }
+}

--- a/aot/samples/TodoEf/TodoEf.csproj
+++ b/aot/samples/TodoEf/TodoEf.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <NativeLib>Shared</NativeLib>
+    <TargetFramework>net10.0</TargetFramework>
+    <RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
+    <RootNamespace>WaspSample.TodoEf</RootNamespace>
+    <AssemblyName>TodoEf</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <SelfContained>true</SelfContained>
+    <NoWarn>$(NoWarn);IL2026;IL3050;CA2255;EF1002</NoWarn>
+    <IlcLlvmTarget>wasm32-wasi</IlcLlvmTarget>
+
+    <EventSourceSupport>false</EventSourceSupport>
+    <MetricsSupport>false</MetricsSupport>
+    <DebuggerSupport>false</DebuggerSupport>
+    <HttpActivityPropagationSupport>false</HttpActivityPropagationSupport>
+    <BuiltInComInteropSupport>false</BuiltInComInteropSupport>
+    <_AggressiveAttributeTrimming>true</_AggressiveAttributeTrimming>
+    <IlcOptimizationPreference>Size</IlcOptimizationPreference>
+    <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="BytecodeAlliance.Componentize.DotNet.Wasm.SDK" Version="0.7.0-preview00010" />
+    <PackageReference Include="runtime.linux-x64.Microsoft.DotNet.ILCompiler.LLVM" Version="10.0.0-alpha.1.25162.1" />
+    <ProjectReference Include="..\..\Wasp.IcCdk\Wasp.IcCdk.csproj" />
+    <ProjectReference Include="..\..\Wasp.AspNetCore\Wasp.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\Wasp.OrthogonalPersistence\Wasp.OrthogonalPersistence.csproj" />
+    <TrimmerRootAssembly Include="TodoEf" />
+    <TrimmerRootAssembly Include="Wasp.IcCdk" />
+    <TrimmerRootAssembly Include="Wasp.AspNetCore" />
+    <TrimmerRootAssembly Include="Wasp.OrthogonalPersistence" />
+    <UnmanagedEntryPointsAssembly Include="TodoEf" />
+    <UnmanagedEntryPointsAssembly Include="Wasp.AspNetCore" />
+  </ItemGroup>
+
+  <Target Name="StripWasmComponentTypeWit" BeforeTargets="LinkNativeLlvm">
+    <ItemGroup>
+      <WasmComponentTypeWit Remove="@(WasmComponentTypeWit)" />
+    </ItemGroup>
+  </Target>
+
+  <Import Project="..\..\Wasp.AspNetCore\Wasp.AspNetCore.targets" />
+
+</Project>

--- a/aot/samples/TodoEf/build-and-deploy.sh
+++ b/aot/samples/TodoEf/build-and-deploy.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO"
+
+echo "[todoef] AOT-compiling for wasm32-wasi via docker..."
+docker run --rm --platform linux/amd64 -v "$REPO:/work" -v wasp-nuget:/nuget \
+  wasp-dotnet-build:latest \
+  bash -c "cd /work/aot/samples/TodoEf && dotnet build -c Release /p:IlcLlvmTarget=wasm32-wasi"
+
+RAW=aot/samples/TodoEf/bin/Release/net10.0/wasi-wasm/publish/TodoEf.wasm
+OUT=aot/samples/TodoEf/TodoEf.canister.wasm
+TMP=$(mktemp -t wasp-tef.XXXXXX.wasm)
+TMP2=$(mktemp -t wasp-tef.XXXXXX.wasm)
+
+echo "[todoef] icp-publish..."
+shared/tools/icp-publish/icp-publish.sh "$RAW" "$TMP"
+echo "[todoef] wasi-stub..."
+shared/tools/wasi-stub/target/release/wasi-stub "$TMP" "$TMP2"
+echo "[todoef] wasm-opt..."
+wasm-opt -Oz \
+  --enable-bulk-memory --enable-multivalue --enable-reference-types \
+  --enable-simd --enable-nontrapping-float-to-int --enable-sign-ext \
+  "$TMP2" -o "$OUT"
+
+echo "[todoef] Deploying..."
+cd aot
+dfx canister create todoef 2>/dev/null || true
+dfx canister install todoef --mode reinstall --yes --wasm samples/TodoEf/TodoEf.canister.wasm
+echo "[todoef] http://$(dfx canister id todoef).raw.localhost:4944/"

--- a/aot/samples/TodoEf/todoef.did
+++ b/aot/samples/TodoEf/todoef.did
@@ -1,0 +1,24 @@
+service : {
+    http_request : (record {
+        method : text;
+        url : text;
+        headers : vec record { text; text };
+        body : blob;
+    }) -> (record {
+        status_code : nat16;
+        headers : vec record { text; text };
+        body : blob;
+        upgrade : opt bool;
+    }) query;
+    http_request_update : (record {
+        method : text;
+        url : text;
+        headers : vec record { text; text };
+        body : blob;
+    }) -> (record {
+        status_code : nat16;
+        headers : vec record { text; text };
+        body : blob;
+        upgrade : opt bool;
+    });
+}


### PR DESCRIPTION
## Summary
- New library `Wasp.OrthogonalPersistence` — `WaspDbContext` + `WaspDbSet<T>` mirror EF Core's surface (Add / Remove / Find / LINQ / SaveChanges) but persist to canister stable memory instead of SQL.
- New sample `samples/TodoEf` — Minimal API todo backend exercising the full CRUD round trip + upgrade-survival.
- Unit tests for `WaspDbSet<T>` (4/4 pass).

## Why not actual EF Core
`Microsoft.EntityFrameworkCore` + `Microsoft.EntityFrameworkCore.InMemory` pushed the wasm to 14.4 MB, past the IC's 11.5 MB code-section limit. The current shape ships in ~7 MB and gives developers the same mental model (DbContext subclass + DbSet<T> + LINQ + SaveChanges).

## Test plan
- [x] `dotnet test Wasp.OrthogonalPersistence.Tests` → 4/4 pass
- [x] `aot/samples/TodoEf/build-and-deploy.sh` → wasm under 11.5 MB limit, deploys cleanly
- [x] Local dfx CRUD: POST 3 todos → toggle → delete → GET shows correct state
- [x] **Upgrade survival**: \`dfx canister install --mode upgrade\` after CRUD → stable-memory data fully restored

## Files of interest
- \`aot/Wasp.OrthogonalPersistence/src/WaspDbContext.cs\` — registers sets, drives snapshot/load
- \`aot/Wasp.OrthogonalPersistence/src/WaspDbSet.cs\` — list-backed entity collection
- \`aot/Wasp.OrthogonalPersistence/src/Storage.cs\` — single-chunk stable-memory layout ("WAOP" magic + version + length)
- \`aot/samples/TodoEf/TodoContext.cs\` — example DbContext subclass

🤖 Generated with [Claude Code](https://claude.com/claude-code)